### PR TITLE
[Technical Support] AUI-3094 Datatable handles incorrectly new line characters in textarea field

### DIFF
--- a/src/aui-datatable/HISTORY.md
+++ b/src/aui-datatable/HISTORY.md
@@ -4,7 +4,7 @@
 
 ## @VERSION@
 
-No registries yet.
+* [AUI-3094](https://issues.liferay.com/browse/AUI-3094) Datatable handles incorrectly new line characters in textarea field.
 
 ## [3.1.0](https://github.com/liferay/alloy-ui/releases/tag/3.1.0)
 

--- a/src/aui-datatable/assets/aui-datatable-core-core.css
+++ b/src/aui-datatable/assets/aui-datatable-core-core.css
@@ -79,6 +79,10 @@
 /*
 * custom
 */
+.table-cell {
+    white-space: pre-wrap;
+}
+
 .table-sortable-column {
     cursor: pointer;
 }

--- a/src/aui-datatable/js/aui-datatable-base-cell-editor.js
+++ b/src/aui-datatable/js/aui-datatable-base-cell-editor.js
@@ -132,7 +132,7 @@ BaseCellEditor = A.Component.create({
                         val = A.Lang.String.unescapeEntities(val);
                     }
 
-                    val = val.replace(REGEX_BR, 'n');
+                    val = val.replace(REGEX_BR, '\n');
                 }
 
                 return val;

--- a/src/aui-datatable/js/aui-datatable-cell-editor-support.js
+++ b/src/aui-datatable/js/aui-datatable-cell-editor-support.js
@@ -199,7 +199,7 @@ A.mix(CellEditorSupport.prototype, {
 
         editor.set('value', event.newVal);
 
-        record.set(column.key, event.newVal);
+        record.set(column.key, editor.formatValue(editor.get('outputFormatter'), event.newVal));
 
         instance._refocusActiveCell();
     },


### PR DESCRIPTION
Hi Dustin,

In LPS-69892 we described a DDL issue which is reproducible on different portal version in different cases.
Firstly we need to fix it on master and this issue is totally fixable with some aui datatable changes.

Please watch my attached gif to aui ticket as well.

Thanks in advance,
 Zsaga