### PR TITLE
AUI-3099 Using 'makeImageVisible' behavior to update scroll position …

### DIFF
--- a/src/aui-image-viewer/assets/aui-image-viewer-gallery-core.css
+++ b/src/aui-image-viewer/assets/aui-image-viewer-gallery-core.css
@@ -50,3 +50,11 @@
     padding-bottom: 10px;
     text-align: center;
 }
+.image-gallery-pagination .pagination-content {
+    overflow: hidden;
+    white-space: nowrap;
+}
+
+.image-gallery-pagination .pagination-content > li {
+    display: inline-block !important;
+}

--- a/src/aui-image-viewer/js/aui-image-viewer-gallery.js
+++ b/src/aui-image-viewer/js/aui-image-viewer-gallery.js
@@ -359,8 +359,13 @@ var ImageGallery = A.Component.create({
             instance.on('pausedChange', instance._onPausedChange);
             instance.on('currentIndexChange', instance._onCurrentIndexChange);
 
-            instance.publish('changeRequest', {
-                defaultFn: this._changeRequest
+            instance.publish({
+                changeRequest: {
+                    defaultFn: this._changeRequest
+                },
+                makeImageVisible: {
+                    defaultFn: this._defMakeImageVisible
+                }
             });
         },
 
@@ -470,6 +475,28 @@ var ImageGallery = A.Component.create({
 
             if (instance._timer) {
                 instance._timer.cancel();
+            }
+        },
+
+        /**
+         * Default behavior for the `makeImageVisible` event. The scroll position is
+         * updated to make the specified image visible.
+         *
+         * @method _defMakeImageVisible
+         * @protected
+         */
+        _defMakeImageVisible: function(event) {
+            var instance = this;
+            var paginationEl = instance.get(PAGINATION_EL);
+            var imageRegion = paginationEl.all('.' + CSS_IMAGE_GALLERY_PAGINATION_THUMB).item(event.index).get('region');
+            var list = paginationEl.one('.pagination-content');
+            var listRegion = list.get('region');
+
+            if (imageRegion.left < listRegion.left) {
+                list.set('scrollLeft', list.get('scrollLeft') - (listRegion.left - imageRegion.left));
+            }
+            else if (imageRegion.right > listRegion.right) {
+                list.set('scrollLeft', list.get('scrollLeft') + imageRegion.right - listRegion.right);
             }
         },
 
@@ -637,6 +664,10 @@ var ImageGallery = A.Component.create({
             var linksCount = instance.get(LINKS).size(),
                 paginationInstance = instance.get(PAGINATION_INSTANCE),
                 total = paginationInstance.get(TOTAL);
+
+            instance.fire('makeImageVisible', {
+                index: page - 1
+            });
 
             if (linksCount > total) {
                 var offset = parseInt(page / total, 10) * total + 1;


### PR DESCRIPTION
…of thumbnail list

Hi Dustin,

I'm sending you an ImageViewerGallery change to 2.0.x branch for a review. This is not reproducible on master because in the last 3 years were a huge refactoring on ImageViewer components. But, I used an applied solution from master.

Shortly, too many thumbnail images(when those are showed in 2 or 3 rows)are overlapping the current main image.
In my solution I used css and I let these thumbnails elements to be in only one row. Furthermore I used a message from master that scrolls these elements in its parent node.

I have already talked about this issue with Jon Mak and we agreed that we need to backport aui-image-viewer-multiple component to 2.0.x. Unfortunately, about master branch contains a huge changes and another dependencies I decided that I will backport the needed code only.

Let me know if you'd have any questions.

Thans in advance, Zsaga